### PR TITLE
Food item menu fix (with pointer cursor)

### DIFF
--- a/frontend/src/components/FoodItem/FoodItem.css
+++ b/frontend/src/components/FoodItem/FoodItem.css
@@ -10,6 +10,7 @@
     flex-direction: column;
     height: 100%;
     background: white;
+    cursor: pointer;
 }
 
 .food-item:hover {

--- a/frontend/src/components/FoodItem/FoodItem.jsx
+++ b/frontend/src/components/FoodItem/FoodItem.jsx
@@ -55,7 +55,7 @@ const FoodItem = ({id,name,size,price,description,image,stock}) => {
           {isOutOfStock ? (
             <div className="out-of-stock-badge">Out of Stock</div>
           ) : (
-            <div className="view-details-badge">View Details</div>
+            <div className="view-details-badge">Click the image to add to cart</div>
           )}
         </div>
         <div className="food-item-info">


### PR DESCRIPTION
Fixing pointer cursor and badge text for food items. The cursor now indicates that the item is clickable, and the badge text has been updated to "Click the image to add to cart" for better user guidance.