### PR TITLE
Admin fix02b

### DIFF
--- a/admin/src/pages/Receipt/Receipt.css
+++ b/admin/src/pages/Receipt/Receipt.css
@@ -279,8 +279,7 @@
   .receipt-order-list,
   .receipt-btn-print,
   .sidebar,
-  .navbar,
-  .app-content {
+  .navbar {
     display: none !important;
   }
   .receipt-preview {
@@ -288,6 +287,17 @@
     top: 0;
     left: 0;
     right: 0;
+    z-index: 9999;
+    width: auto;
+    padding: 0;
+  }
+  .receipt {
+    margin: 0;
+    padding: 0;
+  }
+  .receipt-content {
+    display: block !important;
+    height: auto !important;
   }
   .receipt-paper {
     border: none;

--- a/admin/src/pages/Receipt/Receipt.jsx
+++ b/admin/src/pages/Receipt/Receipt.jsx
@@ -29,7 +29,8 @@ const Receipt = ({ url }) => {
     return (
       (o.receiptNumber && o.receiptNumber.toLowerCase().includes(q)) ||
       (o._id && o._id.toLowerCase().includes(q)) ||
-      (o.address?.address && o.address.address.toLowerCase().includes(q))
+      (o.address?.address && o.address.address.toLowerCase().includes(q)) ||
+      (o.address?.name && o.address.name.toLowerCase().includes(q))
     );
   });
 
@@ -89,7 +90,7 @@ const Receipt = ({ url }) => {
                   <p><strong>Date:</strong> {new Date(selectedOrder.createdAt).toLocaleString()}</p>
                   <p><strong>Type:</strong> {selectedOrder.orderType || 'Delivery'}</p>
                   {selectedOrder.tableNumber && <p><strong>Table:</strong> {selectedOrder.tableNumber}</p>}
-                  <p><strong>Customer:</strong> {selectedOrder.address?.address || 'Walk-in'}</p>
+                  <p><strong>Customer:</strong> {selectedOrder.address?.name || selectedOrder.address?.address || 'Walk-in'}</p>
                   <p><strong>Staff:</strong> {selectedOrder.staffName || 'N/A'}</p>
                 </div>
                 <div className="receipt-divider">━━━━━━━━━━━━━━━━━━━━</div>
@@ -113,7 +114,7 @@ const Receipt = ({ url }) => {
                   <span className="receipt-total-amount">{formatCurrency(selectedOrder.amount)}</span>
                 </div>
                 <div className="receipt-payment-info">
-                  <p><strong>Payment:</strong> {selectedOrder.paymentMethod || (selectedOrder.payment ? 'Online' : 'Unpaid')}</p>
+                  <p><strong>Payment:</strong> {selectedOrder.paymentMethod || (selectedOrder.payment ? 'stripe' : 'unpaid')}</p>
                   <p><strong>Status:</strong> {selectedOrder.status}</p>
                 </div>
                 <div className="receipt-divider">━━━━━━━━━━━━━━━━━━━━</div>

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -87,7 +87,7 @@ const verifyOrder = async (req,res) => {
     const {orderId,success} = req.body;
     try {
         if (success=="true") {
-            await orderModel.findByIdAndUpdate(orderId,{payment:true});
+            await orderModel.findByIdAndUpdate(orderId,{payment:true, paymentMethod:'stripe'});
             res.json({success:true,message:"Payment successful"});
         }
         else {

--- a/backend/controllers/posController.js
+++ b/backend/controllers/posController.js
@@ -15,7 +15,7 @@ const generateReceiptNumber = () => {
 // Place a POS (in-store) order
 const placePosOrder = async (req, res) => {
     try {
-        const { items, amount, paymentMethod, orderType, tableNumber, staffName, promoCode, customerName } = req.body;
+        const { items, amount, paymentMethod, orderType, tableNumber, staffName, promoCode, customerName, address: deliveryAddress } = req.body;
 
         if (!items || items.length === 0) {
             return res.json({ success: false, message: "Order must have at least one item" });
@@ -32,11 +32,26 @@ const placePosOrder = async (req, res) => {
 
         const receiptNumber = generateReceiptNumber();
 
+        // Build address object with customer name and delivery details
+        let addressData;
+        if (orderType === 'delivery' && deliveryAddress) {
+            addressData = {
+                ...deliveryAddress,
+                name: customerName || 'Walk-in Customer',
+                address: deliveryAddress.street || customerName || 'Walk-in Customer'
+            };
+        } else {
+            addressData = {
+                name: customerName || 'Walk-in Customer',
+                address: customerName || 'Walk-in Customer'
+            };
+        }
+
         const newOrder = new orderModel({
             userId: req.userId || 'pos-system',
             items: items,
             amount: amount,
-            address: { address: customerName || 'Walk-in Customer' },
+            address: addressData,
             orderType: orderType || 'dine-in',
             tableNumber: tableNumber || null,
             payment: paymentMethod !== 'unpaid' ? true : false,


### PR DESCRIPTION
Fixed the issue of not being able to select a delivery address when placing a POS order. Now, the delivery address can be selected and stored in the database when placing a POS order. For the receipt page, the delivery address will be displayed if it is available. If not, it will show "N/A" instead.